### PR TITLE
Allow images (and shaders) to reuse buffers

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Workaround for https://github.com/npm/npm/issues/17161
+package*.json text eol=lf

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "najadojo-gltf-import-export",
-  "version": "1.0.0",
+  "name": "gltf-import-export",
+  "version": "1.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gltf-import-export",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gltf-import-export",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Convert between GLB and GLTF files",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/importProvider.ts
+++ b/src/importProvider.ts
@@ -79,7 +79,7 @@ function doConversion(sourceBuf: Buffer, targetFilename: string) {
     // returns any image objects for the given bufferView index if the buffer view is an image
     function findImagesForBufferView(bufferViewIndex: number) : Array<any> {
         if (gltf.images !== undefined && gltf.images instanceof Array) {
-            return gltf.images.filter((i : any) => i.bufferView === bufferViewIndex)
+            return gltf.images.filter((i : any) => i.bufferView === bufferViewIndex);
         }
         return [];
     }
@@ -106,7 +106,7 @@ function doConversion(sourceBuf: Buffer, targetFilename: string) {
     // returns any shaders for the given bufferView index if the buffer view is an image
     function findShadersForBufferView(bufferViewIndex: number) : Array<any> {
         if (gltf.shaders !== undefined && gltf.shaders instanceof Array) {
-            return gltf.shaders.filter((s : any) => s.bufferView === bufferViewIndex)
+            return gltf.shaders.filter((s : any) => s.bufferView === bufferViewIndex);
         }
         return [];
     }


### PR DESCRIPTION
Hey @najadojo, I get to send you a PR for a change.

This one fixes AnalyticalGraphicsInc/gltf-vscode#80.  In that issue, @zellski has a model where multiple `image` blocks in a GLB refer to the same internal buffer.  I'm not sure that's good practice in general, as one could more easily re-use the same image index number.  But, it doesn't appear to be forbidden by glTF, and it's fixable here.

This change makes a list of `image` blocks that all reference a given bufferView index, and will adapt all of them to use the newly created filesystem file.  There's a baked-in assumption that the first reference to a bufferView will have the correct MIME type and that all following references to the same bufferView will have the same type (because how could they not? It's the same data).  Hopefully this doesn't decrease the readability here, let me know.